### PR TITLE
Bug fixes jvetter1

### DIFF
--- a/src/Com.cpp
+++ b/src/Com.cpp
@@ -30,6 +30,7 @@ Documentation, Forums and more information available at http://www.brewtroller.c
 #include "Config.h"
 #include "BrewTroller.h"
 #include "Com_BTPD.h"
+#include "Com_RGBIO8.h"
 #include "Com.h"
 
 //Function Forward Declarations

--- a/src/Com_BTnic.h
+++ b/src/Com_BTnic.h
@@ -39,78 +39,78 @@ Documentation, Forums and more information available at http://www.brewtroller.c
  ********************************************************************************************************************/
   // Using Values 65-90 & 97-122 for command codes to make terminal input easier 
   // but any value between 0-255 can be used with the following exceptions
-  // Command Field Char		9	(Tab)
-  // Command Term Char		10	(Line Feed)
-  // Command Term Char		13	(Carriage Return)
+  // Command Field Char         9  (Tab)
+  // Command Term Char          10 (Line Feed)
+  // Command Term Char          13 (Carriage Return)
 
   //Command codes for special responses
-  #define CMD_REJECT        33	//!
-  #define CMD_REJECT_PARAM  35	//#
-  #define CMD_REJECT_INDEX  36	//$
-  #define CMD_REJECT_CRC     42	// *
+  #define CMD_REJECT            33  //!
+  #define CMD_REJECT_PARAM      35  //#
+  #define CMD_REJECT_INDEX      36  //$
+  #define CMD_REJECT_CRC        42  //*
 
-  #define CMD_GET_PROGNAMES     62      //%3E
-  #define CMD_SET_PROGRAM       63      //%3F
-  #define CMD_GET_PROGRAM       64      //%40
-  #define CMD_GET_BOIL		65 	//A
-  #define CMD_GET_CAL		66 	//B
-  #define CMD_GET_EVAP		67 	//C
-  #define CMD_GET_OSET		68 	//D
-  #define CMD_GET_PROG		69 	//E
-  #define CMD_GET_TS		70 	//F
-  #define CMD_GET_VER		71 	//G
-  #define CMD_GET_VSET		72 	//H
-  #define CMD_INIT_EEPROM	73 	//I
-  #define CMD_SCAN_TS		74 	//J
-  #define CMD_SET_BOIL		75 	//K
-  #define CMD_SET_CAL		76 	//L
-  #define CMD_SET_EVAP		77 	//M
-  #define CMD_SET_OSET		78 	//N
-  #define CMD_SET_PROG		79 	//O
-  #define CMD_SET_TS		80 	//P
-  #define CMD_SET_VLVCFG	81 	//Q
-  #define CMD_SET_VSET		82 	//R
-  #define CMD_ADV_STEP		83 	//S
-  #define CMD_EXIT_STEP		84 	//T
-  #define CMD_INIT_STEP		85 	//U
-  #define CMD_SET_ALARM		86 	//V
-  #define CMD_SET_AUTOVLV	87 	//W
-  #define CMD_SET_SETPOINT	88 	//X
-  #define CMD_SET_TIMERSTATUS	89 	//Y
-  #define CMD_SET_TIMERVALUE	90 	//Z
-  #define CMD_GET_PROGNAME	91 	//'['
-  #define CMD_SET_PROGNAME	92 	//'\'
-  #define CMD_GET_PROGTEMPS	93 	//']'
-  #define CMD_SET_PROGTEMPS	94 	//'^'
-  #define CMD_GET_PROGMINS	95 	//'_'
-  #define CMD_SET_PROGMINS	96 	//'`'
-  #define CMD_GET_STATUS	97 	//a
-  #define CMD_SET_VLVPRF	98 	//b
-  #define CMD_RESET		99 	//c
-  #define CMD_GET_VLVCFG	100 	//d
-  #define CMD_GET_ALARM		101 	//e
-  #define CMD_GET_BOILPWR	102 	//f
-  #define CMD_GET_DELAYTIME	103 	//g
-  #define CMD_GET_GRAINTEMP	104 	//h
-  #define CMD_SET_BOILPWR	105 	//i
-  #define CMD_SET_DELAYTIME	106 	//j
-  #define CMD_SET_GRAINTEMP	107 	//k
-  #define CMD_STEPPRG		110 	//n
-  #define CMD_TIMER		111 	//o
-  #define CMD_VOL		112 	//p
-  #define CMD_TEMP		113 	//q
-  #define CMD_STEAM		114 	//r
-  #define CMD_HEATPWR		115 	//s
-  #define CMD_SETPOINT		116 	//t
-  #define CMD_AUTOVLV		117 	//u
-  #define CMD_VLVBITS		118 	//v
-  #define CMD_VLVPRF		119 	//w
-  #define CMD_GET_PROGVOLS	120 	//x
-  #define CMD_SET_PROGVOLS	121 	//y
-  #define CMD_SET_TGTVOL        123     //{
-  #define CMD_GET_TGTVOL        124     //|
-  #define CMD_SET_BOILCTL       125     //}
-  #define CMD_GET_BOILCTL       126     //~
+  #define CMD_GET_PROGNAMES     62  //%3E
+  #define CMD_SET_PROGRAM       63  //%3F
+  #define CMD_GET_PROGRAM       64  //%40
+  #define CMD_GET_BOIL          65  //A
+  #define CMD_GET_CAL           66  //B
+  #define CMD_GET_EVAP          67  //C
+  #define CMD_GET_OSET          68  //D
+  #define CMD_GET_PROG          69  //E
+  #define CMD_GET_TS            70  //F
+  #define CMD_GET_VER           71  //G
+  #define CMD_GET_VSET          72  //H
+  #define CMD_INIT_EEPROM       73  //I
+  #define CMD_SCAN_TS           74  //J
+  #define CMD_SET_BOIL          75  //K
+  #define CMD_SET_CAL           76  //L
+  #define CMD_SET_EVAP          77  //M
+  #define CMD_SET_OSET          78  //N
+  #define CMD_SET_PROG          79  //O
+  #define CMD_SET_TS            80  //P
+  #define CMD_SET_VLVCFG        81  //Q
+  #define CMD_SET_VSET          82  //R
+  #define CMD_ADV_STEP          83  //S
+  #define CMD_EXIT_STEP         84  //T
+  #define CMD_INIT_STEP         85  //U
+  #define CMD_SET_ALARM         86  //V
+  #define CMD_SET_AUTOVLV       87  //W
+  #define CMD_SET_SETPOINT      88  //X
+  #define CMD_SET_TIMERSTATUS   89  //Y
+  #define CMD_SET_TIMERVALUE    90  //Z
+  #define CMD_GET_PROGNAME      91  //'['
+  #define CMD_SET_PROGNAME      92  //'\'
+  #define CMD_GET_PROGTEMPS     93  //']'
+  #define CMD_SET_PROGTEMPS     94  //'^'
+  #define CMD_GET_PROGMINS      95  //'_'
+  #define CMD_SET_PROGMINS      96  //'`'
+  #define CMD_GET_STATUS        97  //a
+  #define CMD_SET_VLVPRF        98  //b
+  #define CMD_RESET             99  //c
+  #define CMD_GET_VLVCFG        100 //d
+  #define CMD_GET_ALARM         101 //e
+  #define CMD_GET_BOILPWR       102 //f
+  #define CMD_GET_DELAYTIME     103 //g
+  #define CMD_GET_GRAINTEMP     104 //h
+  #define CMD_SET_BOILPWR       105 //i
+  #define CMD_SET_DELAYTIME     106 //j
+  #define CMD_SET_GRAINTEMP     107 //k
+  #define CMD_STEPPRG           110 //n
+  #define CMD_TIMER             111 //o
+  #define CMD_VOL               112 //p
+  #define CMD_TEMP              113 //q
+  #define CMD_STEAM             114 //r
+  #define CMD_HEATPWR           115 //s
+  #define CMD_SETPOINT          116 //t
+  #define CMD_AUTOVLV           117 //u
+  #define CMD_VLVBITS           118 //v
+  #define CMD_VLVPRF            119 //w
+  #define CMD_GET_PROGVOLS      120 //x
+  #define CMD_SET_PROGVOLS      121 //y
+  #define CMD_SET_TGTVOL        123 //{
+  #define CMD_GET_TGTVOL        124 //|
+  #define CMD_SET_BOILCTL       125 //}
+  #define CMD_GET_BOILCTL       126 //~
   
   typedef enum {
     BTNIC_STATE_IDLE,
@@ -130,60 +130,60 @@ Documentation, Forums and more information available at http://www.brewtroller.c
     0,  //CMD_GET_PROGNAMES (All)
     22, //CMD_SET_PROGRAM (Full)
     0,  //CMD_GET_PROGRAM (Full)
-    0,	//CMD_GET_BOIL
-    0,	//CMD_GET_CAL
-    0,	//CMD_GET_EVAP
-    0,	//CMD_GET_OSET
-    0,	//CMD_GET_PROG
-    0,	//CMD_GET_TS
-    0,	//CMD_GET_VER
-    0,	//CMD_GET_VSET
-    1,	//CMD_INIT_EEPROM
-    0,	//CMD_SCAN_TS
-    1,	//CMD_SET_BOIL
-    2,	//CMD_SET_CAL
-    1,	//CMD_SET_EVAP
-    8,	//CMD_SET_OSET
-    6,	//CMD_SET_PROG
-    8,	//CMD_SET_TS
-    1,	//CMD_SET_VLVCFG
-    2,	//CMD_SET_VSET
-    0,	//CMD_ADV_STEP
-    0,	//CMD_EXIT_STEP
-    1,	//CMD_INIT_STEP
-    1,	//CMD_SET_ALARM
-    1,	//CMD_SET_AUTOVLV
-    1,	//CMD_SET_SETPOINT
-    1,	//CMD_SET_TIMERSTATUS
-    1,	//CMD_SET_TIMERVALUE
+    0,  //CMD_GET_BOIL
+    0,  //CMD_GET_CAL
+    0,  //CMD_GET_EVAP
+    0,  //CMD_GET_OSET
+    0,  //CMD_GET_PROG
+    0,  //CMD_GET_TS
+    0,  //CMD_GET_VER
+    0,  //CMD_GET_VSET
+    1,  //CMD_INIT_EEPROM
+    0,  //CMD_SCAN_TS
+    1,  //CMD_SET_BOIL
+    2,  //CMD_SET_CAL
+    1,  //CMD_SET_EVAP
+    8,  //CMD_SET_OSET
+    6,  //CMD_SET_PROG
+    8,  //CMD_SET_TS
+    1,  //CMD_SET_VLVCFG
+    2,  //CMD_SET_VSET
+    0,  //CMD_ADV_STEP
+    0,  //CMD_EXIT_STEP
+    1,  //CMD_INIT_STEP
+    1,  //CMD_SET_ALARM
+    1,  //CMD_SET_AUTOVLV
+    1,  //CMD_SET_SETPOINT
+    1,  //CMD_SET_TIMERSTATUS
+    1,  //CMD_SET_TIMERVALUE
     0,  //CMD_GET_PROGNAME
     1,  //CMD_SET_PROGNAME
     0,  //CMD_GET_PROGMASHTEMPS
     6,  //CMD_SET_PROGMASHTEMPS
     0,  //CMD_GET_PROGMASHMINS
     6,  //CMD_SET_PROGMASHMINS
-    0,	//CMD_GET_STATUS
-    2,	//CMD_SET_VLVPRF
-    0,	//CMD_RESET
-    0,	//CMD_GET_VLVCFG
-    0,	//CMD_GET_ALARM
-    0,	//CMD_GET_BOILPWR
-    0,	//CMD_GET_DELAYTIME
-    0,	//CMD_GET_GRAINTEMP
-    1,	//CMD_SET_BOILPWR
-    1,	//CMD_SET_DELAYTIME
-    1,	//CMD_SET_GRAINTEMP
-    0,	//Unused
-    0,	//Unused
-    0,	//CMD_STEPPRG
-    0,	//CMD_TIMER
-    0,	//CMD_VOL
-    0,	//CMD_TEMP
-    0,	//CMD_STEAM
-    0,	//CMD_HEATPWR
-    0,	//CMD_SETPOINT
-    0,	//CMD_AUTOVLV
-    0,	//CMD_VLVBITS
+    0,  //CMD_GET_STATUS
+    2,  //CMD_SET_VLVPRF
+    0,  //CMD_RESET
+    0,  //CMD_GET_VLVCFG
+    0,  //CMD_GET_ALARM
+    0,  //CMD_GET_BOILPWR
+    0,  //CMD_GET_DELAYTIME
+    0,  //CMD_GET_GRAINTEMP
+    1,  //CMD_SET_BOILPWR
+    1,  //CMD_SET_DELAYTIME
+    1,  //CMD_SET_GRAINTEMP
+    0,  //Unused
+    0,  //Unused
+    0,  //CMD_STEPPRG
+    0,  //CMD_TIMER
+    0,  //CMD_VOL
+    0,  //CMD_TEMP
+    0,  //CMD_STEAM
+    0,  //CMD_HEATPWR
+    0,  //CMD_SETPOINT
+    0,  //CMD_AUTOVLV
+    0,  //CMD_VLVBITS
     0,  //CMD_VLVPRF
     0,  //CMD_GET_PROGVOLS
     3,  //CMD_SET_PROGVOLS
@@ -191,72 +191,72 @@ Documentation, Forums and more information available at http://www.brewtroller.c
     1,  //CMD_SET_TGTVOL
     0,  //CMD_GET_TGTVOL
     2,  //CMD_SET_BOILCNT
-    0  //CMD_GET_BOILCNT
+    0   //CMD_GET_BOILCNT
   };
 
   static const byte CMD_INDEX_MAXVALUE[] PROGMEM =
   {
     0,                  //CMD_GET_PROGNAMES (All)
-    RECIPE_MAX - 1,   //CMD_SET_PROGRAM (Full)
-    RECIPE_MAX - 1,  //CMD_GET_PROGRAM (Full)
-    0, 			//CMD_GET_BOIL
-    29, 		//CMD_GET_CAL (0-9 HLT, 10-19 Mash, 20-29 Kettle)
-    0, 			//CMD_GET_EVAP
-    VS_STEAM, 		//CMD_GET_OSET
-    RECIPE_MAX - 1, 	//CMD_GET_PROG
-    NUM_TS - 1, 	//CMD_GET_TS
-    0, 			//CMD_GET_VER
-    VS_KETTLE, 		//CMD_GET_VSET
-    0, 			//CMD_INIT_EEPROM
-    0, 			//CMD_SCAN_TS
-    0, 			//CMD_SET_BOIL
-    29,	                //CMD_SET_CAL (0-9 HLT, 10-19 Mash, 20-29 Kettle)
-    0, 			//CMD_SET_EVAP
-    VS_STEAM, 		//CMD_SET_OSET
-    RECIPE_MAX - 1, 	//CMD_SET_PROG
-    NUM_TS - 1, 	//CMD_SET_TS
-    NUM_VLVCFGS - 1, 	//CMD_SET_VLVCFG
-    VS_KETTLE, 		//CMD_SET_VSET
+    RECIPE_MAX - 1,     //CMD_SET_PROGRAM (Full)
+    RECIPE_MAX - 1,     //CMD_GET_PROGRAM (Full)
+    0,                  //CMD_GET_BOIL
+    29,                 //CMD_GET_CAL (0-9 HLT, 10-19 Mash, 20-29 Kettle)
+    0,                  //CMD_GET_EVAP
+    VS_STEAM,           //CMD_GET_OSET
+    RECIPE_MAX - 1,     //CMD_GET_PROG
+    NUM_TS - 1,         //CMD_GET_TS
+    0,                  //CMD_GET_VER
+    VS_KETTLE,          //CMD_GET_VSET
+    0,                  //CMD_INIT_EEPROM
+    0,                  //CMD_SCAN_TS
+    0,                  //CMD_SET_BOIL
+    29,                 //CMD_SET_CAL (0-9 HLT, 10-19 Mash, 20-29 Kettle)
+    0,                  //CMD_SET_EVAP
+    VS_STEAM,           //CMD_SET_OSET
+    RECIPE_MAX - 1,     //CMD_SET_PROG
+    NUM_TS - 1,         //CMD_SET_TS
+    NUM_VLVCFGS - 1,    //CMD_SET_VLVCFG
+    VS_KETTLE,          //CMD_SET_VSET
     BREWSTEP_COUNT - 1, //CMD_ADV_STEP
     BREWSTEP_COUNT - 1, //CMD_EXIT_STEP
     BREWSTEP_COUNT - 1, //CMD_INIT_STEP
-    0, 			//CMD_SET_ALARM
-    0, 			//CMD_SET_AUTOVLV
-    VS_STEAM, 		//CMD_SET_SETPOINT
-    TIMER_BOIL, 	//CMD_SET_TIMERSTATUS
-    TIMER_BOIL, 	//CMD_SET_TIMERVALUE
-    RECIPE_MAX - 1, 	//CMD_GET_PROGNAME
-    RECIPE_MAX - 1, 	//CMD_SET_PROGNAME
-    RECIPE_MAX - 1, 	//CMD_GET_PROGTEMPS
-    RECIPE_MAX - 1, 	//CMD_SET_PROGTEMPS
-    RECIPE_MAX - 1, 	//CMD_GET_PROGMINS
-    RECIPE_MAX - 1, 	//CMD_SET_PROGMINS
-    0, 			//CMD_GET_STATUS
-    0, 			//CMD_SET_VLVPRF
-    1, 			//CMD_RESET
-    NUM_VLVCFGS - 1, 	//CMD_GET_VLVCFG
-    0, 			//CMD_GET_ALARM
-    0, 			//CMD_GET_BOILPWR
-    0, 			//CMD_GET_DELAYTIME
-    0, 			//CMD_GET_GRAINTEMP
-    0, 			//CMD_SET_BOILPWR
-    0, 			//CMD_SET_DELAYTIME
-    0, 			//CMD_SET_GRAINTEMP
-    0, 	                //Unused
-    0, 	                //Unused
-    0, 			//CMD_STEPPRG
-    TIMER_BOIL, 	//CMD_TIMER
-    VS_KETTLE, 		//CMD_VOL
-    VS_KETTLE, 		//CMD_TEMP
-    0, 			//CMD_STEAM
-    VS_STEAM, 		//CMD_HEATPWR
-    VS_STEAM, 		//CMD_SETPOINT
-    0, 			//CMD_AUTOVLV
-    0, 			//CMD_VLVBITS
-    0, 			//CMD_VLVPRF
-    RECIPE_MAX - 1,   //CMD_GET_PROGVOLS
-    RECIPE_MAX - 1,   //CMD_SET_PROGVOLS
-    0, 	                //Unused
+    0,                  //CMD_SET_ALARM
+    0,                  //CMD_SET_AUTOVLV
+    VS_STEAM,           //CMD_SET_SETPOINT
+    TIMER_BOIL,         //CMD_SET_TIMERSTATUS
+    TIMER_BOIL,         //CMD_SET_TIMERVALUE
+    RECIPE_MAX - 1,     //CMD_GET_PROGNAME
+    RECIPE_MAX - 1,     //CMD_SET_PROGNAME
+    RECIPE_MAX - 1,     //CMD_GET_PROGTEMPS
+    RECIPE_MAX - 1,     //CMD_SET_PROGTEMPS
+    RECIPE_MAX - 1,     //CMD_GET_PROGMINS
+    RECIPE_MAX - 1,     //CMD_SET_PROGMINS
+    0,                  //CMD_GET_STATUS
+    0,                  //CMD_SET_VLVPRF
+    1,                  //CMD_RESET
+    NUM_VLVCFGS - 1,    //CMD_GET_VLVCFG
+    0,                  //CMD_GET_ALARM
+    0,                  //CMD_GET_BOILPWR
+    0,                  //CMD_GET_DELAYTIME
+    0,                  //CMD_GET_GRAINTEMP
+    0,                  //CMD_SET_BOILPWR
+    0,                  //CMD_SET_DELAYTIME
+    0,                  //CMD_SET_GRAINTEMP
+    0,                  //Unused
+    0,                  //Unused
+    0,                  //CMD_STEPPRG
+    TIMER_BOIL,         //CMD_TIMER
+    VS_KETTLE,          //CMD_VOL
+    NUM_TS - 1,         //CMD_TEMP
+    0,                  //CMD_STEAM
+    VS_STEAM,           //CMD_HEATPWR
+    VS_STEAM,           //CMD_SETPOINT
+    0,                  //CMD_AUTOVLV
+    0,                  //CMD_VLVBITS
+    0,                  //CMD_VLVPRF
+    RECIPE_MAX - 1,     //CMD_GET_PROGVOLS
+    RECIPE_MAX - 1,     //CMD_SET_PROGVOLS
+    0,                  //Unused
     VS_KETTLE,          //CMD_SET_TGTVOL
     VS_KETTLE,          //CMD_GET_TGTVOL
     0,                  //CMD_SET_BOILCTL

--- a/src/Com_RGBIO8.cpp
+++ b/src/Com_RGBIO8.cpp
@@ -1,11 +1,6 @@
-#ifdef RGBIO8_ENABLE
-
-#include "Config.h"
 #include "Com_RGBIO8.h"
 
-#define SOFTSWITCH_OFF 0
-#define SOFTSWITCH_ON 1
-#define SOFTSWITCH_AUTO 2
+#ifdef RGBIO8_ENABLE
 
 byte softSwitchPv[PVOUT_COUNT];
 byte softSwitchHeat[HEAT_OUTPUTS_COUNT];

--- a/src/Com_RGBIO8.h
+++ b/src/Com_RGBIO8.h
@@ -1,12 +1,21 @@
-#include "Config.h"
-
 #ifndef COM_RGBIO8_H
 #define COM_RGBIO8_H
+
+#include "BrewTroller.h"
+#include "Config.h"
+
 
 #ifdef RGBIO8_ENABLE
 
 #define RGBIO8_MAX_OUTPUT_RECIPES 4
 #define RGBIO8_INTERVAL 100
+
+#define SOFTSWITCH_OFF 0
+#define SOFTSWITCH_ON 1
+#define SOFTSWITCH_AUTO 2
+
+extern byte softSwitchHeat[HEAT_OUTPUTS_COUNT];
+extern byte softSwitchPv[PVOUT_COUNT];
 
 struct RGBIO8_output_assignment {
   byte type;
@@ -99,6 +108,9 @@ class RGBIO8 {
     void setOutput(byte output, uint16_t rgb);
     uint8_t crc8(uint8_t inCrc, uint8_t inData );
 };
+
+void RGBIO8_Init();
+void RGBIO8_Update();
 
 #endif
 

--- a/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
@@ -27,7 +27,7 @@ BrewTroller Phoenix HERMS Hardware Configuration
   #define KETTLEHEAT_PIN 14
 
   #define DIGITAL_INPUTS
-  #define DIGIN_COUNT 8
+  #define DIGIN_COUNT 9
   #define DIGIN1_PIN 31
   #define DIGIN2_PIN 30
   #define DIGIN3_PIN 29
@@ -36,6 +36,7 @@ BrewTroller Phoenix HERMS Hardware Configuration
   #define DIGIN6_PIN 19
   #define DIGIN7_PIN 20
   #define DIGIN8_PIN 21
+  #define DIGIN9_PIN 22 //estop
 
   #define RS485_SERIAL_PORT 1
   #define RS485_RTS_PIN    23

--- a/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
@@ -28,7 +28,7 @@ BrewTroller Phoenix RIMS/Direct Fired Hardware Configuration
   #define KETTLEHEAT_PIN 14
 
   #define DIGITAL_INPUTS
-  #define DIGIN_COUNT 8
+  #define DIGIN_COUNT 9
   #define DIGIN1_PIN 31
   #define DIGIN2_PIN 30
   #define DIGIN3_PIN 29
@@ -37,6 +37,7 @@ BrewTroller Phoenix RIMS/Direct Fired Hardware Configuration
   #define DIGIN6_PIN 19
   #define DIGIN7_PIN 20
   #define DIGIN8_PIN 21
+  #define DIGIN9_PIN 22 //estop
 
   #define RS485_SERIAL_PORT 1
   #define RS485_RTS_PIN    23

--- a/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
@@ -26,7 +26,7 @@ BrewTroller Phoenix Single Vessel Hardware Configuration
   #define HLTHEAT_PIN 12
 
   #define DIGITAL_INPUTS
-  #define DIGIN_COUNT 8
+  #define DIGIN_COUNT 9
   #define DIGIN1_PIN 31
   #define DIGIN2_PIN 30
   #define DIGIN3_PIN 29
@@ -35,6 +35,7 @@ BrewTroller Phoenix Single Vessel Hardware Configuration
   #define DIGIN6_PIN 19
   #define DIGIN7_PIN 20
   #define DIGIN8_PIN 21
+  #define DIGIN9_PIN 22 //estop
 
   #define RS485_SERIAL_PORT 1
   #define RS485_RTS_PIN    23

--- a/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
@@ -39,6 +39,7 @@ BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
   #define DIGIN6_PIN 19
   #define DIGIN7_PIN 20
   #define DIGIN8_PIN 21
+  #define DIGIN9_PIN 22 //estop
 
   #define RS485_SERIAL_PORT 1
   #define RS485_RTS_PIN    23

--- a/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
@@ -30,7 +30,7 @@ BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
   #define PWMPUMP_PIN 15
 
   #define DIGITAL_INPUTS
-  #define DIGIN_COUNT 8
+  #define DIGIN_COUNT 9 
   #define DIGIN1_PIN 31
   #define DIGIN2_PIN 30
   #define DIGIN3_PIN 29

--- a/src/Outputs.cpp
+++ b/src/Outputs.cpp
@@ -31,6 +31,7 @@ Documentation, Forums and more information available at http://www.brewtroller.c
 #include "EEPROM.h"
 #include "Outputs.h"
 #include "Events.h"
+#include "Com_RGBIO8.h"
 
 extern const int HEAT_OUTPUTS_COUNT;
 

--- a/src/Outputs.cpp
+++ b/src/Outputs.cpp
@@ -205,6 +205,15 @@ void pinInit() {
     #if DIGIN_COUNT > 5
       digInPin[5].setup(DIGIN6_PIN, INPUT);
     #endif
+    #if DIGIN_COUNT > 6
+      digInPin[6].setup(DIGIN7_PIN, INPUT);
+    #endif
+    #if DIGIN_COUNT > 7
+      digInPin[7].setup(DIGIN8_PIN, INPUT);
+    #endif
+    #if DIGIN_COUNT > 8
+      digInPin[8].setup(DIGIN9_PIN, INPUT);
+    #endif
   #endif
 }
 

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -1679,7 +1679,7 @@ unsigned long ulpow(unsigned long base, unsigned long exponent) {
  * Prompt the user for a value in hex. The value is shown with 0x prepended
  * and the user may only select 0-f for each digit.
  */
-unsigned long getHexValue(char sTitle[], unsigned long defValue) {
+unsigned long getHexValue(const char sTitle[], unsigned long defValue) {
     unsigned long retValue = defValue;
     byte cursorPos = 0;
     boolean cursorState = 0; //0 = Unselected, 1 = Selected
@@ -2050,8 +2050,7 @@ void menuSetup() {
     }
 }
 
-#ifdef RGBIO8_ENABLE
-#ifdef RGBIO8_SETUP
+#if defined(RGBIO8_ENABLE) && defined(RGBIO8_SETUP)
 
 void cfgRgb() {
     byte targetAddr = 0x7f;
@@ -2070,10 +2069,10 @@ void cfgRgb() {
         m.setItem_P(UIStrings::Generic::EXIT, 255);
         byte lastOption = scrollMenu("RGB Setup", &m);
         if (lastOption == 0) {
-            targetAddr = (byte) getHexValue("Target Address", targetAddr);
+            targetAddr = (byte) getHexValue(UIStrings::SystemSetup::RGBIO::TARGET_ADDR, targetAddr);
         }
         else if (lastOption == 1) {
-            byte address = (byte) getHexValue("Set Address", targetAddr);
+            byte address = (byte) getHexValue(UIStrings::SystemSetup::RGBIO::SET_ADDR, targetAddr);
             RGBIO8 rgb;
             rgb.begin(0, targetAddr);
             rgb.setAddress(address);
@@ -2098,7 +2097,6 @@ void cfgRgb() {
     }
 }
 
-#endif
 #endif
 
 void assignSensor() {

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -1718,7 +1718,6 @@ unsigned long getHexValue(const char sTitle[], unsigned long defValue) {
             }
             else {
                 cursorPos = encValue;
-                multiplier = ulpow(16, (digits - cursorPos - 1));
                 for (byte i = valuePos - 1; i < valuePos - 1 + digits; i++) {
                     LCD.writeCustChar(2, i, 0);
                 }
@@ -1729,6 +1728,7 @@ unsigned long getHexValue(const char sTitle[], unsigned long defValue) {
                     LCD.print_P(3, 11, UIStrings::Generic::LESS_SYM);
                 }
                 else {
+                    multiplier = ulpow(16, (digits - cursorPos - 1));
                     if (cursorPos < digits) {
                         LCD.writeCustChar(2, valuePos + cursorPos - 1, 1);
                     }

--- a/src/UIStrings.cpp
+++ b/src/UIStrings.cpp
@@ -493,13 +493,11 @@ namespace UIStrings {
       
         //RGBIO8 Config Menu
         namespace RGBIO {
-#ifdef RGBIO8_ENABLE
-#ifdef RGBIO8_SETUP
-            const char TARGET_ADDR[] PROGMEM = "Target Addr:";
+#if defined(RGBIO8_ENABLE) && defined(RGBIO8_SETUP)
+            const char TARGET_ADDR[] PROGMEM = "Target Address";
             const char SET_ADDR[] PROGMEM = "Set Address";
             const char IDENTIFY[] PROGMEM = "Identify";
             const char RESTART[] PROGMEM = "Restart";
-#endif
 #endif
         }
         


### PR DESCRIPTION
Includes five fixes I found while enabling RGBIO and e-stop boards
1. CMD_TEMP had it's command index set to the number of kettles instead of number of temp sensors
2. RGBIO would not compile when enabled
3. Some of the strings for the RGBIO code deviated from the norm regarding CONST
4. getHexValue could hang in some edge cases when setting the RGBIO address
5. Missing extra pin support in phoenix, including e-stop pin
