### PR TITLE
Feature/board temp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,23 @@
 .idea
 .iml
 
-#build directory
+# build directory
 build/*
+
+# CMake Files
+Config.h
+Makefile
+CMakeCache.txt
+CMakeFiles/*
+cmake_install.cmake
+lib/CMakeFiles/*
+lib/Makefile
+lib/cmake_install.cmake
+src/CMakeFiles/*
+src/Makefile
+src/cmake_install.cmake
+
+# Output Files
+BrewTroller-*.hex
+BrewTroller-*.elf
+BrewTroller-*.map

--- a/src/BrewTroller.cpp
+++ b/src/BrewTroller.cpp
@@ -136,8 +136,8 @@ byte vSensor[3] = { HLTVOL_APIN, MASHVOL_APIN, KETTLEVOL_APIN};
 #endif
 
 //8-byte Temperature Sensor Address x9 Sensors
-byte tSensor[9][8];
-int temp[9];
+byte tSensor[NUM_TS][TEMP_ADDR_SIZE];
+int temp[NUM_TS];
 
 //Volume in (thousandths of gal/l)
 unsigned long tgtVol[3], volAvg[3], calibVols[3][10];

--- a/src/BrewTroller.h
+++ b/src/BrewTroller.h
@@ -8,6 +8,7 @@
 #include <PID_Beta6.h>
 
 #include "HardwareProfile.h"
+#include "Temp.h"
 #include "PVOut.h"
 #include "UI_LCD.h"
 
@@ -79,8 +80,8 @@ extern pin hbPin;
 extern byte vSensor[3];
 
 //8-byte Temperature Sensor Address x9 Sensors
-extern byte tSensor[9][8];
-extern int temp[9];
+extern byte tSensor[NUM_TS][TEMP_ADDR_SIZE];
+extern int temp[NUM_TS];
 
 //Volume in (thousandths of gal/l)
 extern unsigned long tgtVol[3], volAvg[3], calibVols[3][10];

--- a/src/Com_BTnic.h
+++ b/src/Com_BTnic.h
@@ -578,13 +578,13 @@ void BTnic::execCmd(void) {
       
     case CMD_SET_TS:  //P
       {
-        byte addr[8];
-        for (byte i=0; i<8; i++) addr[i] = (byte)getCmdParamNum(i+1);
+        byte addr[TEMP_ADDR_SIZE];
+        for (byte i=0; i<TEMP_ADDR_SIZE; i++) addr[i] = (byte)getCmdParamNum(i+1);
         setTSAddr(cmdIndex, addr);
       }
     case CMD_GET_TS:  //F
       logFieldCmd(CMD_GET_TS, cmdIndex);
-      for (byte i=0; i<8; i++) logFieldI(tSensor[cmdIndex][i]);
+      for (byte i=0; i<TEMP_ADDR_SIZE; i++) logFieldI(tSensor[cmdIndex][i]);
       break;
       
       
@@ -622,9 +622,9 @@ void BTnic::execCmd(void) {
     case CMD_SCAN_TS:  //J
       {
         logFieldCmd(CMD_SCAN_TS, NO_CMDINDEX);
-        byte tsAddr[8];
+        byte tsAddr[TEMP_ADDR_SIZE];
         getDSAddr(tsAddr);
-        for (byte i=0; i<8; i++) logFieldI(tsAddr[i]);
+        for (byte i=0; i<TEMP_ADDR_SIZE; i++) logFieldI(tsAddr[i]);
       }
       break;
       

--- a/src/Com_S0ASC.cpp
+++ b/src/Com_S0ASC.cpp
@@ -125,11 +125,11 @@ boolean chkMsg() {
           initEEPROM();
         } else if(strcasecmp(msg[0], "SCAN_TS") == 0) {
           clearMsg();
-          byte tsAddr[8];
+          byte tsAddr[TEMP_ADDR_SIZE];
           getDSAddr(tsAddr);
           logStart_P(LOGCFG);
           logField_P(PSTR("TS_SCAN")); 
-          for (byte i=0; i<8; i++) logFieldI(tsAddr[i]);
+          for (byte i=0; i<TEMP_ADDR_SIZE; i++) logFieldI(tsAddr[i]);
           logEnd();
         } else if(strcasecmp(msg[0], "SET_BOIL") == 0) {
           if (msgField == 1) {
@@ -214,8 +214,8 @@ boolean chkMsg() {
         } else if(strcasecmp(msg[0], "SET_TS") == 0) {
           byte val = atoi(msg[1]);
           if (msgField == 9 && val >= TS_HLT && val < NUM_TS) {
-            byte addr[8];
-            for (byte i=0; i<8; i++) addr[i] = (byte)atoi(msg[i+2]);
+            byte addr[TEMP_ADDR_SIZE];
+            for (byte i=0; i<TEMP_ADDR_SIZE; i++) addr[i] = (byte)atoi(msg[i+2]);
             setTSAddr(val, addr);
             clearMsg();
             logTSensor(val);

--- a/src/EEPROM.cpp
+++ b/src/EEPROM.cpp
@@ -172,7 +172,7 @@ void loadSetup() {
 //TSensors: HLT (0-7), MASH (8-15), KETTLE (16-23), H2OIN (24-31), H2OOUT (32-39), 
 //          BEEROUT (40-47), AUX1 (48-55), AUX2 (56-63), AUX3 (64-71)
 //**********************************************************************************
-void setTSAddr(byte sensor, byte addr[8]) {
+void setTSAddr(byte sensor, byte addr[TEMP_ADDR_SIZE]) {
     #ifdef HLT_AS_KETTLE
     if (sensor == TS_HLT || sensor == TS_KETTLE) {
       //Also copy HLT setting to Kettle

--- a/src/EEPROM.h
+++ b/src/EEPROM.h
@@ -21,7 +21,7 @@ void loadVlvModbus(byte board);
 //TSensors: HLT (0-7), MASH (8-15), KETTLE (16-23), H2OIN (24-31), H2OOUT (32-39),
 //          BEEROUT (40-47), AUX1 (48-55), AUX2 (56-63), AUX3 (64-71)
 //**********************************************************************************
-void setTSAddr(byte sensor, byte addr[8]);
+void setTSAddr(byte sensor, byte addr[TEMP_ADDR_SIZE]);
 
 //**********************************************************************************
 //PID Enabled (72); Bit 1 = HLT, Bit 2 = Mash, Bit 3 = Kettle, Bit 4 = Steam

--- a/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
@@ -23,8 +23,8 @@ BrewTroller Phoenix HERMS Hardware Configuration
   #define MUX_ENABLE_PIN 2
   #define MUX_ENABLE_LOGIC 0
   
-  #define HLTHEAT_PIN 12
-  #define KETTLEHEAT_PIN 14
+  #define HLTHEAT_PIN 12    //Output Terminal 1
+  #define KETTLEHEAT_PIN 14 //Output Terminal 3
 
   #define DIGITAL_INPUTS
   #define DIGIN_COUNT 9

--- a/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
@@ -96,6 +96,11 @@ BrewTroller Phoenix HERMS Hardware Configuration
   #define DS2482_ADDR 0x1B
   //**********************************************************************************
 
+  //  Enables lookup of the board temperature
+  #define TC74_BOARD_TEMP
+  #define TC74_I2C_ADDR 0x48
+  // Enable to track and monitor board temperature
+  #define MONITOR_BOARD_TEMP
 
   //**********************************************************************************
   // Serial0 Communication Options

--- a/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
@@ -85,7 +85,7 @@ BrewTroller Phoenix HERMS Hardware Configuration
   //   11-bit (0.125C  / 0.225F ) = 375ms 
   //   10-bit (0.25C   / 0.45F  ) = 188ms 
   //    9-bit (0.5C    / 0.9F   ) =  94ms   
-  #define TS_ONEWIRE_RES 11
+  #define TS_ONEWIRE_RES 12
   
   // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
   // 2 bytes of temperature data and ignoring CRC check.

--- a/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
@@ -86,7 +86,7 @@ BrewTroller Phoenix RIMS/Direct Fired Hardware Configuration
   //   11-bit (0.125C  / 0.225F ) = 375ms 
   //   10-bit (0.25C   / 0.45F  ) = 188ms 
   //    9-bit (0.5C    / 0.9F   ) =  94ms   
-  #define TS_ONEWIRE_RES 11
+  #define TS_ONEWIRE_RES 12
   
   // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
   // 2 bytes of temperature data and ignoring CRC check.

--- a/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
@@ -97,6 +97,11 @@ BrewTroller Phoenix RIMS/Direct Fired Hardware Configuration
   #define DS2482_ADDR 0x1B
   //**********************************************************************************
 
+  //  Enables lookup of the board temperature
+  #define TC74_BOARD_TEMP
+  #define TC74_I2C_ADDR 0x48
+  // Enable to track and monitor board temperature
+  #define MONITOR_BOARD_TEMP
 
   //**********************************************************************************
   // Serial0 Communication Options

--- a/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
@@ -23,9 +23,9 @@ BrewTroller Phoenix RIMS/Direct Fired Hardware Configuration
   #define MUX_ENABLE_PIN 2
   #define MUX_ENABLE_LOGIC 0
   
-  #define HLTHEAT_PIN 12
-  #define MASHHEAT_PIN 13
-  #define KETTLEHEAT_PIN 14
+  #define HLTHEAT_PIN 12    //Output Terminal 1
+  #define MASHHEAT_PIN 13   //Output Terminal 2
+  #define KETTLEHEAT_PIN 14 //Output Terminal 3
 
   #define DIGITAL_INPUTS
   #define DIGIN_COUNT 9

--- a/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
@@ -23,7 +23,7 @@ BrewTroller Phoenix Single Vessel Hardware Configuration
   #define MUX_ENABLE_PIN 2
   #define MUX_ENABLE_LOGIC 0
   
-  #define HLTHEAT_PIN 12
+  #define HLTHEAT_PIN 12  //Output Terminal 1
 
   #define DIGITAL_INPUTS
   #define DIGIN_COUNT 9

--- a/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
@@ -84,7 +84,7 @@ BrewTroller Phoenix Single Vessel Hardware Configuration
   //   11-bit (0.125C  / 0.225F ) = 375ms 
   //   10-bit (0.25C   / 0.45F  ) = 188ms 
   //    9-bit (0.5C    / 0.9F   ) =  94ms   
-  #define TS_ONEWIRE_RES 11
+  #define TS_ONEWIRE_RES 12
   
   // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
   // 2 bytes of temperature data and ignoring CRC check.

--- a/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
@@ -95,6 +95,11 @@ BrewTroller Phoenix Single Vessel Hardware Configuration
   #define DS2482_ADDR 0x1B
   //**********************************************************************************
 
+  //  Enables lookup of the board temperature
+  #define TC74_BOARD_TEMP
+  #define TC74_I2C_ADDR 0x48
+  // Enable to track and monitor board temperature
+  #define MONITOR_BOARD_TEMP
 
   //**********************************************************************************
   // Serial0 Communication Options

--- a/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
@@ -88,7 +88,7 @@ BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
   //   11-bit (0.125C  / 0.225F ) = 375ms 
   //   10-bit (0.25C   / 0.45F  ) = 188ms 
   //    9-bit (0.5C    / 0.9F   ) =  94ms   
-  #define TS_ONEWIRE_RES 11
+  #define TS_ONEWIRE_RES 12
   
   // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
   // 2 bytes of temperature data and ignoring CRC check.

--- a/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
@@ -99,6 +99,11 @@ BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
   #define DS2482_ADDR 0x1B
   //**********************************************************************************
 
+  //  Enables lookup of the board temperature
+  #define TC74_BOARD_TEMP
+  #define TC74_I2C_ADDR 0x48
+  // Enable to track and monitor board temperature
+  #define MONITOR_BOARD_TEMP
 
   //**********************************************************************************
   // Serial0 Communication Options

--- a/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
@@ -43,8 +43,7 @@ BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
 
   #define RS485_SERIAL_PORT 1
   #define RS485_RTS_PIN    23
-  //#define PVOUT_TYPE_MODBUS
-  //#define NUM_MODBUS_BOARDS 1
+  #define PVOUT_TYPE_MODBUS
   
   #define HLTVOL_APIN 7
   #define MASHVOL_APIN 6

--- a/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
@@ -23,11 +23,11 @@ BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
   #define MUX_ENABLE_PIN 2
   #define MUX_ENABLE_LOGIC 0
   
-  #define HLTHEAT_PIN 12
-  #define MASHHEAT_PIN 13
-  #define KETTLEHEAT_PIN 14
-  #define STEAMHEAT_PIN 15
-  #define PWMPUMP_PIN 15
+  #define HLTHEAT_PIN 12     //Output Terminal 1
+  #define MASHHEAT_PIN 13    //Output Terminal 2
+  #define KETTLEHEAT_PIN 14  //Output Terminal 3
+  #define STEAMHEAT_PIN 15   //Output Terminal 4
+  #define PWMPUMP_PIN 15     //Output Terminal 4
 
   #define DIGITAL_INPUTS
   #define DIGIN_COUNT 9 
@@ -43,7 +43,8 @@ BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
 
   #define RS485_SERIAL_PORT 1
   #define RS485_RTS_PIN    23
-  #define PVOUT_TYPE_MODBUS
+  //#define PVOUT_TYPE_MODBUS
+  //#define NUM_MODBUS_BOARDS 1
   
   #define HLTVOL_APIN 7
   #define MASHVOL_APIN 6

--- a/src/Temp.cpp
+++ b/src/Temp.cpp
@@ -214,7 +214,7 @@ Documentation, Forums and more information available at http://www.brewtroller.c
 #else
   void tempInit() {}
   void updateTemps() {}
-  void getDSAddr(byte addrRet[8]){};
+  void getDSAddr(byte addrRet[TEMP_ADDR_SIZE]){};
 #endif // TS_ONEWIRE
 
 #if defined MASH_AVG

--- a/src/Temp.cpp
+++ b/src/Temp.cpp
@@ -29,6 +29,36 @@ Documentation, Forums and more information available at http://www.brewtroller.c
 #include "Enum.h"
 #include "BrewTroller.h"
 
+#if TS_ONEWIRE_RES == 12
+#define CONV_DELAY 750
+#define RES_VALUE 0x7F
+#elif TS_ONEWIRE_RES == 11
+#define CONV_DELAY 375
+#define RES_VALUE 0x5F
+#elif TS_ONEWIRE_RES == 10
+#define CONV_DELAY 188
+#define RES_VALUE 0x3F
+#else //Default to 9-bit
+#define CONV_DELAY 94
+#define RES_VALUE 0x1F
+#endif
+
+#define MAX_SCAN_COUNT       20    // Number of devices to scan for
+#define SCRATCHPAD_SIZE      9     // Size of the scratchpad in bytes
+#define CRC_SIZE             8     // Size ofthe CRC in bytes
+#define CRC_INDEX            8     // Index of CRC in the scratchpad
+
+#define DS18B20_IDENT        0x28
+#define DS18S20_IDENT        0x10
+
+#define CONVERT_TEMP_CMD     0x44
+#define WRITE_SCRATCHPAD_CMD 0x4E
+#define COPY_SCRATCHPAD_CMD  0x48
+#define READ_SCRATCHPAD_CMD  0xBE
+
+#define TL_REGISTER          0x46
+#define TH_REGISTER          0x4B
+
 #ifdef TS_ONEWIRE
   #ifdef TS_ONEWIRE_GPIO
     #include <OneWire.h>
@@ -42,7 +72,17 @@ Documentation, Forums and more information available at http://www.brewtroller.c
   #endif
   //One Wire Bus on
 
-void tempInit() {
+  boolean tsReady();
+  boolean validAddr(byte* addr);
+  //Returns Int representing hundreths of degree
+  int readTemp(byte* addr);
+  #if defined MASH_AVG
+    void mashAvg();
+  #endif
+
+  unsigned long convStart;
+
+  void tempInit() {
     for (byte i = 0; i < NUM_TS; i++) temp[i] = BAD_TEMP;
     #ifdef TS_ONEWIRE_I2C
     masterIsConfigured = ds.configure(dsConfig);
@@ -50,40 +90,17 @@ void tempInit() {
     #endif
     ds.reset();
     ds.skip();
-    ds.write(0x4E, TS_ONEWIRE_PPWR); //Write to scratchpad
-    ds.write(0x4B, TS_ONEWIRE_PPWR); //Default value of TH reg (user byte 1)
-    ds.write(0x46, TS_ONEWIRE_PPWR); //Default value of TL reg (user byte 2)
-
-    #if TS_ONEWIRE_RES == 12
-      ds.write(0x7F, TS_ONEWIRE_PPWR); //Config Reg (12-bit)
-    #elif TS_ONEWIRE_RES == 11
-    ds.write(0x5F, TS_ONEWIRE_PPWR); //Config Reg (11-bit)
-    #elif TS_ONEWIRE_RES == 10
-      ds.write(0x3F, TS_ONEWIRE_PPWR); //Config Reg (10-bit)
-    #else //Default to 9-bit
-      ds.write(0x1F, TS_ONEWIRE_PPWR); //Config Reg (9-bit)
-    #endif
-
+    ds.write(WRITE_SCRATCHPAD_CMD, TS_ONEWIRE_PPWR); //Write to scratchpad
+    ds.write(TH_REGISTER, TS_ONEWIRE_PPWR); //Default value of TH reg (user byte 1)
+    ds.write(TL_REGISTER, TS_ONEWIRE_PPWR); //Default value of TL reg (user byte 2)
+    ds.write(RES_VALUE, TS_ONEWIRE_PPWR);
     ds.reset();
     ds.skip();
-    ds.write(0x48, TS_ONEWIRE_PPWR); //Copy scratchpad to EEPROM
+    ds.write(COPY_SCRATCHPAD_CMD, TS_ONEWIRE_PPWR); //Copy scratchpad to EEPROM
     #ifdef TS_ONEWIRE_I2C
     }
     #endif
-}
-
-
-  unsigned long convStart;
-  
-  #if TS_ONEWIRE_RES == 12
-    #define CONV_DELAY 750
-  #elif TS_ONEWIRE_RES == 11
-    #define CONV_DELAY 375
-  #elif TS_ONEWIRE_RES == 10
-    #define CONV_DELAY 188
-  #else //Default to 9-bit
-    #define CONV_DELAY 94
-  #endif
+  }
 
   void updateTemps() {
     #ifdef TS_ONEWIRE_I2C
@@ -95,12 +112,12 @@ void tempInit() {
     if (convStart == 0) {
       ds.reset();
       ds.skip();
-      ds.write(0x44, TS_ONEWIRE_PPWR); //Start conversion
+      ds.write(CONVERT_TEMP_CMD, TS_ONEWIRE_PPWR); //Start conversion
       convStart = millis();   
     } else if (tsReady() || millis() - convStart >= CONV_DELAY) {
       for (byte i = 0; i < NUM_TS; i++) {
         if (validAddr(tSensor[i]))
-          temp[i] = read_temp(tSensor[i]); 
+          temp[i] = readTemp(tSensor[i]);
         else 
           temp[i] = BAD_TEMP;
       }
@@ -127,54 +144,41 @@ void tempInit() {
   }
   
   boolean validAddr(byte* addr) {
-    for (byte i = 0; i < 8; i++) if (addr[i]) return 1;
+    for (byte i = 0; i < TEMP_ADDR_SIZE; i++) if (addr[i]) return 1;
     return 0;
   }
   
-  //This function search for an address that is not currently assigned!
-  void getDSAddr(byte addrRet[8]){
+  //This function searchs for an address that is not currently assigned!
+  void getDSAddr(byte addrRet[TEMP_ADDR_SIZE]) {
     //Leaving stub for external functions (serial and setup) that use this function
-    byte scanAddr[8];
+    byte scanAddr[TEMP_ADDR_SIZE];
     ds.reset_search();
-    byte limit = 0;
-    //Scan at most 20 sensors (In case the One Wire Search loop issue occurs)
-    while (limit <= 20) {
+    //Limit scan count in case the One Wire Search loop issue occurs
+    for (byte limit = 0; limit <= MAX_SCAN_COUNT; ++limit) {
       if (!ds.search(scanAddr)) {
         //No Sensor found, Return
         ds.reset_search();
-        return;
+        break;
       }
-      if (
-          scanAddr[0] == 0x28 ||  //DS18B20
-          scanAddr[0] == 0x10     //DS18S20
-         ) 
-      {
-        boolean found = 0;
+      if (scanAddr[0] == DS18B20_IDENT || scanAddr[0] == DS18S20_IDENT) {
+        bool found = false;
         for (byte i = 0; i <  NUM_TS; i++) {
-          boolean match = 1;
-          for (byte j = 0; j < 8; j++) {
-            //Try to confirm a match by checking every byte of the scanned address with those of each sensor.
-            if (scanAddr[j] != tSensor[i][j]) {
-              match = 0;
-              break;
-            }
-          }
-          if (match) { 
-            found = 1;
+          if (memcmp(scanAddr, tSensor[i], TEMP_ADDR_SIZE) == 0) {
+            found = true;
             break;
           }
         }
         if (!found) {
-          for (byte k = 0; k < 8; k++) addrRet[k] = scanAddr[k];
+          memcpy(addrRet, scanAddr, TEMP_ADDR_SIZE);
           return;
         }
       }
-      limit++;
-    }      
+    }
+    memset(addrRet, 0, TEMP_ADDR_SIZE);
   }
-  
-//Returns Int representing hundreths of degree
-  int read_temp(byte* addr) {
+
+  //Returns Int representing hundreths of degree
+  int readTemp(byte* addr) {
     #ifdef TS_ONEWIRE_I2C
     if (!masterIsConfigured) {
         tempInit(); // if the master isn't configured, try again
@@ -182,18 +186,18 @@ void tempInit() {
     if (!masterIsConfigured) return BAD_TEMP; // if we still aren't setup, abort
     #endif
     long tempOut;
-    byte data[9];
+    byte data[SCRATCHPAD_SIZE];
     ds.reset();
     ds.select(addr);   
-    ds.write(0xBE, TS_ONEWIRE_PPWR); //Read Scratchpad
+    ds.write(READ_SCRATCHPAD_CMD, TS_ONEWIRE_PPWR); //Read Scratchpad
     #ifdef TS_ONEWIRE_FASTREAD
       for (byte i = 0; i < 2; i++)
         data[i] = ds.read();
       if ((data[0] & data[1]) == 0xFF)
         return BAD_TEMP;
     #else
-      for (byte i = 0; i < 9; i++) data[i] = ds.read();
-      if (ds.crc8( data, 8) != data[8]) return BAD_TEMP;
+      for (byte i = 0; i < SCRATCHPAD_SIZE; i++) data[i] = ds.read();
+      if (ds.crc8(data, CRC_SIZE) != data[CRC_INDEX]) return BAD_TEMP;
     #endif
 
     tempOut = (data[1] << 8) + data[0];
@@ -211,32 +215,30 @@ void tempInit() {
   void tempInit() {}
   void updateTemps() {}
   void getDSAddr(byte addrRet[8]){};
-#endif
+#endif // TS_ONEWIRE
 
 #if defined MASH_AVG
-void mashAvg() {
-  byte sensorCount = 1;
-  unsigned long avgTemp = temp[TS_MASH];
-  #if defined MASH_AVG_AUX1
-    if (temp[TS_AUX1] != BAD_TEMP) {
-      avgTemp += temp[TS_AUX1];
-      sensorCount++;
-    }
-  #endif
-  #if defined MASH_AVG_AUX2
-    if (temp[TS_AUX2] != BAD_TEMP) {
-      avgTemp += temp[TS_AUX2];
-      sensorCount++;
-    }
-  #endif
-  #if defined MASH_AVG_AUX3
-    if (temp[TS_AUX3] != BAD_TEMP) {
-      avgTemp += temp[TS_AUX3];
-      sensorCount++;
-    }
-  #endif
-  temp[TS_MASH] = avgTemp / sensorCount;
-}
-#endif
-
-
+  void mashAvg() {
+    byte sensorCount = 1;
+    unsigned long avgTemp = temp[TS_MASH];
+    #if defined MASH_AVG_AUX1
+      if (temp[TS_AUX1] != BAD_TEMP) {
+        avgTemp += temp[TS_AUX1];
+        sensorCount++;
+      }
+    #endif
+    #if defined MASH_AVG_AUX2
+      if (temp[TS_AUX2] != BAD_TEMP) {
+        avgTemp += temp[TS_AUX2];
+        sensorCount++;
+      }
+    #endif
+    #if defined MASH_AVG_AUX3
+      if (temp[TS_AUX3] != BAD_TEMP) {
+        avgTemp += temp[TS_AUX3];
+        sensorCount++;
+      }
+    #endif
+    temp[TS_MASH] = avgTemp / sensorCount;
+  }
+#endif // MASH_AVG

--- a/src/Temp.cpp
+++ b/src/Temp.cpp
@@ -45,7 +45,7 @@ Documentation, Forums and more information available at http://www.brewtroller.c
 
 #define MAX_SCAN_COUNT       20    // Number of devices to scan for
 #define SCRATCHPAD_SIZE      9     // Size of the scratchpad in bytes
-#define CRC_SIZE             8     // Size ofthe CRC in bytes
+#define CRC_SIZE             8     // Size of the CRC in bytes
 #define CRC_INDEX            8     // Index of CRC in the scratchpad
 
 #define DS18B20_IDENT        0x28

--- a/src/Temp.h
+++ b/src/Temp.h
@@ -11,4 +11,9 @@ void updateTemps();
 //This function search for an address that is not currently assigned!
 void getDSAddr(byte addrRet[TEMP_ADDR_SIZE]);
 
+// Returns the board temp as a whole degree or BAD_TEMP if there is an error or its not enabled
+int  getBoardTemp();
+// Returns an average board temp (sampled 10 times / minute)
+int  getAvgBoardTemp();
+
 #endif

--- a/src/Temp.h
+++ b/src/Temp.h
@@ -2,25 +2,13 @@
 #define TEMP_H
 
 #include <Arduino.h>
-#include "Temp.h"
 #include "HardwareProfile.h"
 
+#define TEMP_ADDR_SIZE  8     // Number of bytes in an address (i.e. 64 bit)
+
 void tempInit();
-
 void updateTemps();
-
-boolean tsReady();
-
-boolean validAddr(byte* addr);
-
 //This function search for an address that is not currently assigned!
-void getDSAddr(byte addrRet[8]);
-
-//Returns Int representing hundreths of degree
-int read_temp(byte* addr);
-
-#if defined MASH_AVG
-void mashAvg();
-#endif
+void getDSAddr(byte addrRet[TEMP_ADDR_SIZE]);
 
 #endif

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -2155,13 +2155,13 @@ void assignSensor() {
                 LCD.print_P(2,2,UIStrings::SystemSetup::TempSensorAssign::DISCONNECT_WARN2);
                 {
                     if (confirmChoice(UIStrings::Generic::CONTINUE, 3)) {
-                        byte addr[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+                        byte addr[TEMP_ADDR_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0};
                         getDSAddr(addr);
                         setTSAddr(encValue, addr);
                     }
                 }
             } else if (selected == 1) {
-                byte addr[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+                byte addr[TEMP_ADDR_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0};
                 setTSAddr(encValue, addr);
             }
             else if (selected > 2) return;


### PR DESCRIPTION
This feature continues the temp cleanup by removing temp magic numbers through-out the code base and integrates basic support for tracking the on-board temp sensor. The current implementation records an average temperature using 25 samples over 2 minutes. Nothing is done with temperature yet, but the intention is to support an alarm and maybe display on the PID display.
