### PR TITLE
Fixed modbus config persistence bug

### DIFF
--- a/src/EEPROM.cpp
+++ b/src/EEPROM.cpp
@@ -666,23 +666,23 @@ boolean checkConfig() {
     case 0:
       //Supported PID cycle is changing from 1-255 to .1-25.5
       //All current PID cycle settings will be multiplied by 10 to represent tenths (s)
-      for (byte vessel = VS_HLT; vessel <= VS_STEAM; vessel++) EEPROM.write(76 + vessel * 5, EEPROM.read(76 + vessel * 5) * 10);
-      //Set cfgVersion = 1
-      EEPROM.write(2047, 1);
+      for (byte vessel = VS_HLT; vessel <= VS_STEAM; vessel++) {
+        EEPROM.write(76 + vessel * 5, EEPROM.read(76 + vessel * 5) * 10);
+      }
     case 1:
       //Set triggers to disabled by default
       for (byte trig = 0; trig < NUM_TRIGGERS; trig++) EEPROM.write(2050 + trig, 0);
-      EEPROM.write(2047, 2);
     case 2:
-      for (byte i = 0; i < PVOUT_MODBUS_MAXBOARDS; i++)
+      for (byte i = 0; i < PVOUT_MODBUS_MAXBOARDS; i++) {
         setVlvModbusDefaults(i);
-      EEPROM.write(2047, 3);
-    case 3:
-      for (uint8_t i = 0; i < PVOUT_MODBUS_MAXBOARDS; i++) {
-          setVlvModbusDefaults(i);
       }
-      EEPROM.write(2057, 4);
+    case 3:
+      break;
   }
+  if (cfgVersion <=3) {
+    EEPROM.write(2057, cfgVersion+1);
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
Essentially what was happening is the checkConfig was reseting the Modbus eeprom to defaults before the config for the modbus could be reloaded. I removed the modbus initialization from checkConfig version 3 but left the rest the same because I don't fully understand the intent behind this function. 

checkConfig really doesn't make sense to me because its called 3-4 times at startup and the same eeprom settings are made each time. This slows startup and seems pointless. Hopefully Eric can enlighten when he is back as to the point.
