### PR TITLE
Fix MODBUS relay assignment and boil control bug

### DIFF
--- a/src/PVOut.cpp
+++ b/src/PVOut.cpp
@@ -215,6 +215,11 @@ byte MODBUSOutputBank::setAddr(byte newAddr) {
     }
     return result;
 }
+
+byte MODBUSOutputBank::getAddr() {
+    return slaveAddr;
+}
+
 byte MODBUSOutputBank::setIDMode(byte value) {
     return slave.writeSingleRegister(MODBUS_RELAY_REGIDMODE, value);
 }

--- a/src/PVOut.h
+++ b/src/PVOut.h
@@ -72,6 +72,7 @@ public:
     uint32_t     offset();
     byte         detect();
     byte         setAddr(byte newAddr);
+    byte         getAddr();
     byte         setIDMode(byte value);
     byte         getIDMode();
 


### PR DESCRIPTION
This fixed some typos I found in the boil control and logic for assigning MODBUS relay boards.
